### PR TITLE
Fix `grabTicket` when custom regex is used that does not expect a colon

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -9597,7 +9597,7 @@ var __webpack_exports__ = {};
 const core = __nccwpck_require__(2186);
 const github = __nccwpck_require__(5438);
 
-const DEFAULT_TICKET_REGEX = /^[A-Z,a-z]{2,}-\d{1,}:/g;
+const DEFAULT_TICKET_REGEX = /^[A-Z,a-z]{2,}-\d{1,}(?=:)/g;
 
 async function runMain() {
   try {
@@ -9655,12 +9655,12 @@ async function checkIfOldCommentExists(octokit, context, pullRequestNumber) {
  * @param {string} title
  */
 function grabTicket(title, ticketRegex) {
-  const ticketIdWithColon = title.match(ticketRegex)?.[0];
-  if (!ticketIdWithColon) {
+  const ticketId = title.match(ticketRegex)?.[0];
+  if (!ticketId) {
     return null;
   }
 
-  return ticketIdWithColon.slice(0, -1);
+  return ticketId;
 }
 
 runMain();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jira-link-commenter",
-  "version": "2.5",
+  "version": "3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jira-link-commenter",
-      "version": "2.5",
+      "version": "3.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.9.1",

--- a/src/main.js
+++ b/src/main.js
@@ -1,7 +1,7 @@
 const core = require('@actions/core');
 const github = require('@actions/github');
 
-const DEFAULT_TICKET_REGEX = /^[A-Z,a-z]{2,}-\d{1,}:/g;
+const DEFAULT_TICKET_REGEX = /^[A-Z,a-z]{2,}-\d{1,}(?=:)/g;
 
 async function runMain() {
   try {
@@ -59,12 +59,12 @@ async function checkIfOldCommentExists(octokit, context, pullRequestNumber) {
  * @param {string} title
  */
 function grabTicket(title, ticketRegex) {
-  const ticketIdWithColon = title.match(ticketRegex)?.[0];
-  if (!ticketIdWithColon) {
+  const ticketId = title.match(ticketRegex)?.[0];
+  if (!ticketId) {
     return null;
   }
 
-  return ticketIdWithColon.slice(0, -1);
+  return ticketId;
 }
 
 runMain();


### PR DESCRIPTION
I used a custom regex formula `[A-Z,a-z]{2,}-\\d{1,}` with this action because we do not have a set format for pr titles at my company. For a title like `[XYZ-1234] Fix ABC` the bot was commenting with a link to the ticket `XYZ-123` not `XYZ-1234`. 

It looks like this happened because the code is expecting the regex pattern to include a colon at the end. I changed the default regex to match but not capture the colon and removed the code that chopped off the colon at the end of the `ticketId`.