### PR TITLE
Replacing words like jira to auto in codebase

### DIFF
--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -3,15 +3,15 @@ on: pull_request
 jobs:
   example_comment_pr:
     runs-on: ubuntu-latest
-    name: Auto jira link commenter
+    name: Auto auto link commenter
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Comment PR
-        uses: sbimochan/jira-link-commenter@v3.2
+        uses: sbimochan/auto-link-commenter@v3.2
         with:
-          jira-project-url: https://jira.atlassian.net/browse
+          auto-project-url: https://auto.atlassian.net/browse
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           custom-comment: "Thank you for your contribution!!! :confetti_ball:"
           ticket-regex-title: ^[A-Z,a-z]{2,}-\\d{1,}

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -3,15 +3,15 @@ on: pull_request
 jobs:
   example_comment_pr:
     runs-on: ubuntu-latest
-    name: Auto auto link commenter
+    name: Auto link commenter
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Comment PR
-        uses: sbimochan/auto-link-commenter@v3.2
+        uses: sbimochan/jira-link-commenter@v3.2
         with:
-          auto-project-url: https://auto.atlassian.net/browse
+          auto-project-url: https://jira.atlassian.net/browse
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           custom-comment: "Thank you for your contribution!!! :confetti_ball:"
           ticket-regex-title: ^[A-Z,a-z]{2,}-\\d{1,}

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ This action auto comments in pull request with Jira link to it.
 
 ## Settings
 
-- `jira-project-url`
+- `auto-project-url`
 
-**Required** Add your jira link in ticket link format.
+**Required** Add your auto link in ticket link format.
 E.g:
-`https://jira.atlassian.net/browse`
+`https://auto.atlassian.net/browse`
 
 - `ticket-regex-title`
 
@@ -24,16 +24,16 @@ E.g:
 
 Creates a comment in your PR:
 
-Jira Link: https://jira.atlassian.net/browse/JPT-1571
+Jira Link: https://auto.atlassian.net/browse/JPT-1571
 
 ## Example usage
 
 `custom-comment` is (optional)
 
 ```yaml
-uses: actions/jira-link-commenter@v2.4
+uses: actions/auto-link-commenter@v2.4
 with:
-  jira-project-url: "https://jira.atlassian.net/browse"
+  auto-project-url: "https://auto.atlassian.net/browse"
   custom-comment: "Thank you for your contribution! :confetti_ball:"
 ```
 
@@ -45,16 +45,16 @@ on: pull_request
 jobs:
   example_comment_pr:
     runs-on: ubuntu-latest
-    name: Auto jira link commenter
+    name: Auto auto link commenter
     steps:
       - name: Checkout
         uses: actions/checkout@v1
 
       - name: Comment PR
-        uses: sbimochan/jira-link-commenter@v2.4
+        uses: sbimochan/auto-link-commenter@v2.4
 
         with:
-          jira-project-url: https://jira.atlassian.net/browse
+          auto-project-url: https://auto.atlassian.net/browse
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           custom-comment: "Thank you for your contribution! :confetti_ball:"
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Jira link commenter
+# Auto link commenter
 
-This action auto comments in pull request with Jira link to it.
+This action auto comments in pull request with Auto link to it.
 
 > This tool can be used with other project tracking tools like ClickUp as well. Let's explore together!
 
@@ -24,7 +24,7 @@ E.g:
 
 Creates a comment in your PR:
 
-Jira Link: https://auto.atlassian.net/browse/JPT-1571
+Auto Link: https://auto.atlassian.net/browse/JPT-1571
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Auto Link: https://auto.atlassian.net/browse/JPT-1571
 `custom-comment` is (optional)
 
 ```yaml
-uses: actions/auto-link-commenter@v2.4
+uses: actions/jira-link-commenter@v2.4
 with:
   auto-project-url: "https://auto.atlassian.net/browse"
   custom-comment: "Thank you for your contribution! :confetti_ball:"
@@ -45,13 +45,13 @@ on: pull_request
 jobs:
   example_comment_pr:
     runs-on: ubuntu-latest
-    name: Auto auto link commenter
+    name: Auto link commenter
     steps:
       - name: Checkout
         uses: actions/checkout@v1
 
       - name: Comment PR
-        uses: sbimochan/auto-link-commenter@v2.4
+        uses: sbimochan/jira-link-commenter@v2.4
 
         with:
           auto-project-url: https://auto.atlassian.net/browse

--- a/dist/index.js
+++ b/dist/index.js
@@ -9624,7 +9624,7 @@ const { grabTicket, DEFAULT_TICKET_REGEX } = __nccwpck_require__(5574);
 
 async function runMain() {
   try {
-    const jirProjectUrl = core.getInput("jira-project-url");
+    const jirProjectUrl = core.getInput("auto-project-url");
     const githubToken = core.getInput("GITHUB_TOKEN");
     const customComment = core.getInput("custom-comment");
     const ticketRegexRaw = core.getInput("ticket-regex-title");

--- a/dist/index.js
+++ b/dist/index.js
@@ -9646,7 +9646,7 @@ async function runMain() {
       pullRequestNumber
     );
     if (isPrevComment) {
-      console.log("Jira link bot comment already exists.");
+      console.log("Auto link bot comment already exists.");
       return;
     }
     const ticketNumber = grabTicket(
@@ -9659,7 +9659,7 @@ async function runMain() {
     await octokit.rest.issues.createComment({
       ...context.repo,
       issue_number: pullRequestNumber,
-      body: `${customComment} \n Jira link: ${
+      body: `${customComment} \n Auto link: ${
         jirProjectUrl + "/" + ticketNumber
       }`,
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "jira-link-commenter",
+  "name": "auto-link-commenter",
   "version": "3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "jira-link-commenter",
+      "name": "auto-link-commenter",
       "version": "3.1",
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "auto-link-commenter",
+  "name": "jira-link-commenter",
   "version": "3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "auto-link-commenter",
+      "name": "jira-link-commenter",
       "version": "3.1",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "auto-link-commenter",
+  "name": "jira-link-commenter",
   "version": "3.2",
   "description": "This action auto comments in pull request with Auto link to it.",
   "main": "src/main.js",
@@ -10,15 +10,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sbimochan/auto-link-commenter.git"
+    "url": "git+https://github.com/sbimochan/jira-link-commenter.git"
   },
   "keywords": [],
   "author": "Bimochan Shrestha",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/sbimochan/auto-link-commenter/issues"
+    "url": "https://github.com/sbimochan/jira-link-commenter/issues"
   },
-  "homepage": "https://github.com/sbimochan/auto-link-commenter#readme",
+  "homepage": "https://github.com/sbimochan/jira-link-commenter#readme",
   "dependencies": {
     "@actions/core": "^1.9.1",
     "@actions/github": "^5.0.3"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jira-link-commenter",
+  "name": "auto-link-commenter",
   "version": "3.2",
   "description": "This action auto comments in pull request with Jira link to it.",
   "main": "src/main.js",
@@ -10,15 +10,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sbimochan/jira-link-commenter.git"
+    "url": "git+https://github.com/sbimochan/auto-link-commenter.git"
   },
   "keywords": [],
   "author": "Bimochan Shrestha",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/sbimochan/jira-link-commenter/issues"
+    "url": "https://github.com/sbimochan/auto-link-commenter/issues"
   },
-  "homepage": "https://github.com/sbimochan/jira-link-commenter#readme",
+  "homepage": "https://github.com/sbimochan/auto-link-commenter#readme",
   "dependencies": {
     "@actions/core": "^1.9.1",
     "@actions/github": "^5.0.3"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "auto-link-commenter",
   "version": "3.2",
-  "description": "This action auto comments in pull request with Jira link to it.",
+  "description": "This action auto comments in pull request with Auto link to it.",
   "main": "src/main.js",
   "scripts": {
     "test": "jest",

--- a/src/__tests__/delimeter.test.js
+++ b/src/__tests__/delimeter.test.js
@@ -66,7 +66,7 @@ describe("PR title with no semicolon Ticket ID", () => {
       owner: "owner",
       repo: "repo",
       issue_number: 123,
-      body: "Thank you for your contribution!!! :confetti_ball: \n Jira link: https://jira.example.com/TEST-123",
+      body: "Thank you for your contribution!!! :confetti_ball: \n Auto link: https://jira.example.com/TEST-123",
     });
   });
 });

--- a/src/__tests__/main.test.js
+++ b/src/__tests__/main.test.js
@@ -66,7 +66,7 @@ describe('GitHub Action Tests', () => {
       owner: 'owner',
       repo: 'repo',
       issue_number: 123,
-      body: 'Thank you for your contribution!!! :confetti_ball: \n Jira link: https://jira.example.com/TEST-1234',
+      body: 'Thank you for your contribution!!! :confetti_ball: \n Auto link: https://jira.example.com/TEST-1234',
     });
   });
 
@@ -78,7 +78,7 @@ describe('GitHub Action Tests', () => {
     await runMain();
 
     expect(octokit.rest.issues.createComment).not.toHaveBeenCalled();
-    expect(console.log).toHaveBeenCalledWith('Jira link bot comment already exists.');
+    expect(console.log).toHaveBeenCalledWith('Auto link bot comment already exists.');
   });
 
   test('should handle no ticket number found', async () => {

--- a/src/main.js
+++ b/src/main.js
@@ -26,7 +26,7 @@ async function runMain() {
       pullRequestNumber
     );
     if (isPrevComment) {
-      console.log("Jira link bot comment already exists.");
+      console.log("Auto link bot comment already exists.");
       return;
     }
     const ticketNumber = grabTicket(
@@ -39,7 +39,7 @@ async function runMain() {
     await octokit.rest.issues.createComment({
       ...context.repo,
       issue_number: pullRequestNumber,
-      body: `${customComment} \n Jira link: ${
+      body: `${customComment} \n Auto link: ${
         jirProjectUrl + "/" + ticketNumber
       }`,
     });


### PR DESCRIPTION
A new pr in accordance to issue #35.

Replaced all strings jira to auto and correct names and urls to pass the tests.